### PR TITLE
Implement Zend_Acl_Resource_Interface for CatalogSearchSearch

### DIFF
--- a/CatalogSearchPlugin.php
+++ b/CatalogSearchPlugin.php
@@ -169,6 +169,7 @@ class CatalogSearchPlugin extends Omeka_Plugin_AbstractPlugin
     $pageResource = new Zend_Acl_Resource('CatalogSearch_Page');
     $acl->add($indexResource);
     $acl->add($pageResource);
+    $acl->addResource('CatalogSearchSearch');
 
     $acl->allow(array('super', 'admin'), array('CatalogSearch_Index', 'CatalogSearch_Page'));
     $acl->allow(null, 'CatalogSearch_Page', 'show');

--- a/models/CatalogSearchSearch.php
+++ b/models/CatalogSearchSearch.php
@@ -12,13 +12,18 @@
  * The Catalog Search search record class.
  *
  * */
-class CatalogSearchSearch extends Omeka_Record_AbstractRecord
+class CatalogSearchSearch extends Omeka_Record_AbstractRecord implements Zend_Acl_Resource_Interface
 {
 
   public $query_string;
   public $catalog_name;
   public $display;
   public $query_type;
+
+  public function getResourceId()
+  {
+    return 'CatalogSearchSearch';
+  }
 
   public function getRecordUrl($action = 'show')
   {


### PR DESCRIPTION
This is required for use in Omeka_Form_Admin. Otherwise it fails with error:

PHP Catchable fatal error:  Object of class CatalogSearchSearch could not be
converted to string in /home/omeka/omeka/application/libraries/Zend/Acl.php on
line 360